### PR TITLE
Missing a closing `)` on example console.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SVGInjector(mySVGsToInject,
   pngFallback: 'assets/png',
   each: function(svg) {
     // Callback after each SVG is injected
-    console.log('SVG injected: ' + svg.getAttribute('id');
+    console.log('SVG injected: ' + svg.getAttribute('id'));
   }
 },
 function(totalSVGsInjected) {


### PR DESCRIPTION
Those who copy pasta your example to try this out might get tripped up. Not that I would do that...not that there's anything wrong with that...
