### PR TITLE
different forEach approach

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -14,6 +14,26 @@
   var isLocal = window.location.protocol === 'file:';
   var hasSvgSupport = document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1');
 
+  /**
+   * cache (or polyfill for <= IE8) Array.forEach() 
+   * source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+   */
+  var forEach = Array.prototype.forEach || function (fn, scope) {
+    if (this === void 0 || this === null || typeof fn !== 'function') {
+      throw new TypeError();
+    }
+
+    /* jshint bitwise: false */
+    var i, len = this.length >>> 0;
+    /* jshint bitwise: true */
+
+    for (i = 0; i < len; ++i) {
+      if (i in this) {
+        fn.call(scope, this[i], i, this);
+      }
+    }
+  };
+
   // SVG Cache
   var svgCache = {};
 
@@ -204,7 +224,7 @@
       var imgData = [].filter.call(el.attributes, function (at) {
         return (/^data-\w[\w\-]*$/).test(at.name);
       });
-      Array.prototype.forEach.call(imgData, function (dataAttr) {
+      forEach.call(imgData, function (dataAttr) {
         if (dataAttr.name && dataAttr.value) {
           svg.setAttribute(dataAttr.name, dataAttr.value);
         }
@@ -289,28 +309,6 @@
   };
 
   /**
-   * Array.forEach() polyfill for <= IE8
-   * source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
-   */
-  if (!Array.prototype.forEach) {
-    Array.prototype.forEach = function (fn, scope) {
-      if (this === void 0 || this === null || typeof fn !== 'function') {
-        throw new TypeError();
-      }
-
-      /* jshint bitwise: false */
-      var i, len = this.length >>> 0;
-      /* jshint bitwise: true */
-
-      for (i = 0; i < len; ++i) {
-        if (i in this) {
-          fn.call(scope, this[i], i, this);
-        }
-      }
-    };
-  }
-
-  /**
    * SVGInjector
    *
    * Replace the given elements with their full inline SVG DOM elements.
@@ -345,7 +343,7 @@
     // Do the injection...
     if (elements.length !== undefined) {
       var elementsLoaded = 0;
-      Array.prototype.forEach.call(elements, function (element) {
+      forEach.call(elements, function (element) {
         injectElement(element, evalScripts, pngFallback, function (svg) {
           if (eachCallback && typeof (eachCallback) === 'function') eachCallback(svg);
           if (done && elements.length === ++elementsLoaded) done(elementsLoaded);


### PR DESCRIPTION
skipped adding polyfill in favor of caching the `Array.prototype.forEach` (might save a few bytes)
