### PR TITLE
Rewrite all iri reference attribute ids

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -278,29 +278,29 @@
       // contained in parent elements that are hidden, so if you hide the first
       // SVG instance on the page, then all other instances lose their clipping.
       // Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=376027
-      var clipPaths = svg.querySelectorAll('defs clipPath[id]');
-      var newClipPathName;
-      for (var g = 0, clipPathsLen = clipPaths.length; g < clipPathsLen; g++) {
-        newClipPathName = clipPaths[g].id + '-' + injectCount;
-        // :NOTE: using a substring match attr selector here to deal with IE "adding extra quotes in url() attrs"
-        var usingClipPath = svg.querySelectorAll('[clip-path*="' + clipPaths[g].id + '"]');
-        for (var h = 0, usingClipPathLen = usingClipPath.length; h < usingClipPathLen; h++) {
-          usingClipPath[h].setAttribute('clip-path', 'url(#' + newClipPathName + ')');
-        }
-        clipPaths[g].id = newClipPathName;
-      }
 
-      // Do the same for masks
-      var masks = svg.querySelectorAll('defs mask[id]');
-      var newMaskName;
-      for (var i = 0, masksLen = masks.length; i < masksLen; i++) {
-        newMaskName = masks[i].id + '-' + injectCount;
-        // :NOTE: using a substring match attr selector here to deal with IE "adding extra quotes in url() attrs"
-        var usingMask = svg.querySelectorAll('[mask*="' + masks[i].id + '"]');
-        for (var j = 0, usingMaskLen = usingMask.length; j < usingMaskLen; j++) {
-          usingMask[j].setAttribute('mask', 'url(#' + newMaskName + ')');
+      // Handle all defs elements that have iri capable attributes as defined by w3c: http://www.w3.org/TR/SVG/linking.html#processingIRI
+      var defElements = svg.querySelectorAll('defs *[id]');
+      var defRefAttributes = ['clip-path', 'color-profile', 'cursor', 'fill', 'filter', 'marker', 'marker-start', 'marker-mid', 'marker-end', 'mask', 'stroke'];
+      var newDefName, defAttribute;
+
+      // Iterate defs elements with ids
+      for (var g = 0, defsLen = defElements.length; g < defsLen; g++) {
+        newDefName = defElements[g].id + '-' + injectCount;
+
+        // Iterate iri attriubtes
+        for (var h = 0, attributesLen = defRefAttributes.length; h < attributesLen; h++) {
+          defAttribute = defRefAttributes[h];
+
+          // Find elements referencing the defs element in the current attribute
+          // :NOTE: using a substring match attr selector here to deal with IE "adding extra quotes in url() attrs"
+          var usingDef = svg.querySelectorAll('[' + defAttribute + '*="' + defElements[g].id + '"]');
+          for (var i = 0, usingDefLen = usingDef.length; i < usingDefLen; i++) {
+            usingDef[i].setAttribute(defAttribute, 'url(#' + newDefName + ')');
+          }
         }
-        masks[i].id = newMaskName;
+
+        defElements[g].id = newDefName;
       }
 
       // Remove any unwanted/invalid namespaces that might have been added by SVG editing tools


### PR DESCRIPTION
Handle all defs elements that have iri capable attributes as defined by
w3c in http://www.w3.org/TR/SVG/linking.html#processingIRI

Chrome also has problems with patterns, so why not just handle all
iri-reference-capable attributes instead of adding a third loop for just
patterns