### PR TITLE
Minor improvements

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -17,13 +17,12 @@
   function uniqueClasses(list) {
     list = list.split(' ');
 
-    var hasOwn = Object.prototype.hasOwnProperty;
     var hash = {};
     var i = list.length;
     var out = [];
 
     while (i--) {
-      if (!hasOwn.call(hash, list[i])) {
+      if (!hash.hasOwnProperty(list[i])) {
         hash[list[i]] = 1;
         out.unshift(list[i]);
       }

--- a/svg-injector.js
+++ b/svg-injector.js
@@ -17,12 +17,13 @@
   function uniqueClasses(list) {
     list = list.split(' ');
 
+    var hasOwn = Object.prototype.hasOwnProperty;
     var hash = {};
     var i = list.length;
     var out = [];
 
     while (i--) {
-      if (!hash.hasOwnProperty(list[i])) {
+      if (!hasOwn.call(hash, list[i])) {
         hash[list[i]] = 1;
         out.unshift(list[i]);
       }

--- a/svg-injector.js
+++ b/svg-injector.js
@@ -59,7 +59,7 @@
   var injectedElements = [];
 
   // Request Queue
-  var requestQueue = [];
+  var requestQueue = {};
 
   // Script running status
   var ranScripts = {};


### PR DESCRIPTION
Prevent code from fail, if img element will have 'hasOwnProperty' class name, for whatever reason.
Unified undefined use, same style as used in forEach polyfill.
