### PR TITLE
Mismatch when looking up referencing elements

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -307,7 +307,7 @@
           var referencingElements;
           forEach.call(properties, function (property) {
             // :NOTE: using a substring match attr selector here to deal with IE "adding extra quotes in url() attrs"
-            referencingElements = svg.querySelectorAll('[' + property + '*="' + currentId + '"]');
+            referencingElements = svg.querySelectorAll('[' + property + '="url(#' + currentId + ')"]');
             for (var j = 0, referencingElementLen = referencingElements.length; j < referencingElementLen; j++) {
               referencingElements[j].setAttribute(property, 'url(#' + newId + ')');
             }


### PR DESCRIPTION
If you have filter="url(#filter-10)" but are searching for just filter-1, this will get matched. This is what happens in Sketch when you have to 10 or more filters. Not sure if this will cause a problem with some versions of IE.
