### PR TITLE
improve URL file extension regexp

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -187,7 +187,7 @@
     var imgUrl = el.getAttribute('data-src') || el.getAttribute('src');
 
     // We can only inject SVG
-    if (!(/\.svg/i).test(imgUrl)) {
+    if (!(/\.svg($|\?|#)/i).test(imgUrl)) {
       callback('Attempted to inject a file with a non-svg extension: ' + imgUrl);
       return;
     }


### PR DESCRIPTION
current one can report false-positives (anything with `.svg` in the url would pass it, like `www.svg.com` or `www.example.com/foo.svg.bar`)
